### PR TITLE
Add CocoaPods podspec for a future version.

### DIFF
--- a/MTZoomWindow.podspec
+++ b/MTZoomWindow.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name     = 'MTZoomWindow'
+  s.version  = '0.5.1'
+  s.platform = :ios
+  s.summary  = 'A UIWindow that can be used to zoom in a specific UIView and displays it fullscreen.'
+  s.homepage = 'https://github.com/myell0w/MTZoomWindow'
+  s.author   = { 'Matthias Tretter' => 'myell0w@me.com' }
+  s.source   = { :git => 'https://github.com/myell0w/MTZoomWindow.git', :tag => '0.5' }
+
+  s.description = 'This class provides a simple way to zoom a specific UIView and display it '    \
+                  'fullscreen, upon a defined action of the user (uses UIGestureRecognizer to '   \
+                  'detect actions). If the user performs the action on the specified UIView the ' \
+                  'view gets zoomed in animated and is displayed fullscreen, with a black '       \
+                  'background. If the user performs the same gesture again, the UIView gets '     \
+                  'zoomed back out and everything is like it was before.'
+
+  s.requires_arc = true
+  s.source_files = '*.{h,m}'
+end

--- a/Readme.mdown
+++ b/Readme.mdown
@@ -13,7 +13,7 @@ You can use MTZoomWindow like this:
 	// specify size of the UIView when it is zoomed in
 	viewToZoom.zoomedSize = CGSizeMake(300,460);
     viewToZoom.zoomedAutoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    viewToZoom.wrapInScrollViewWhenZoomed = YES;
+    viewToZoom.wrapInScrollviewWhenZoomed = YES;
 
     // find this awesome shortcut for UITapGestureRecognizer in @zwaldowski's BlocksKit
     [viewToZoom whenTapped:^{


### PR DESCRIPTION
Adding this allows users to install the HEAD version directly from your repo, instead of a released version, and fix bug in README example.

The next version does not neccsarilly have to be 0.9.1, but its the
smallest increment, so it will always be a sane version number.
