### PR TITLE
Edit menu is not showing after zooming in

### DIFF
--- a/MTZoomWindow.m
+++ b/MTZoomWindow.m
@@ -138,6 +138,8 @@
                          self.zoomedView.frame = CGRectMake((self.bounds.size.width-size.width)/2.f, (self.bounds.size.height-size.height)/2.f,
                                                             size.width, size.height);
                      } completion:^(BOOL finished) {
+                         [self makeKeyWindow];
+                         
                          id<MTZoomWindowDelegate> delegate = view.zoomDelegate;
 
                          if ([delegate respondsToSelector:@selector(zoomWindow:didZoomInView:)]) {
@@ -171,6 +173,8 @@
                              // hide window
                              self.hidden = YES;
 
+                             [self.zoomedView.window makeKeyWindow];
+                             
                              id<MTZoomWindowDelegate> delegate = self.zoomedView.zoomDelegate;
 
                              if ([delegate respondsToSelector:@selector(zoomWindow:didZoomOutView:)]) {


### PR DESCRIPTION
set zoomed in window a key window
restore key window after zooming out

![Screenshot 2013 03 03 21 26 56](https://f.cloud.github.com/assets/59230/215471/3a016c62-848d-11e2-9e44-c54ac5a643a8.png)
![Screenshot 2013 03 03 21 26 48](https://f.cloud.github.com/assets/59230/215472/3a361aac-848d-11e2-8f19-897d0975c93f.png)

See more about Edit Menu at http://developer.apple.com/library/ios/#documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/AddingCustomEditMenuItems/AddingCustomEditMenuItems.html

To use Edit Menu with MTZoomWindow lower the window level:

```
[MTZoomWindow sharedWindow].windowLevel = UIWindowLevelNormal + 1;
```

as it is set above the status bar by default:
https://github.com/myell0w/MTZoomWindow/blob/master/MTZoomWindow.m#L42
